### PR TITLE
Add API test harness using sample image

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -2,3 +2,4 @@ fastapi
 uvicorn
 openai
 python-multipart
+pytest

--- a/test/test_api.py
+++ b/test/test_api.py
@@ -1,0 +1,41 @@
+from fastapi.testclient import TestClient
+from unittest.mock import patch
+from pathlib import Path
+import sys
+
+sys.path.append(str(Path(__file__).resolve().parent.parent))
+from backend import app, AnalysisResponse, NutritionData
+
+
+async def mock_call_chatgpt5(image, context: str, user_id: str) -> AnalysisResponse:
+    """Return a fixed response for testing without external API calls."""
+    return AnalysisResponse(
+        portion_weight=150.0,
+        nutrition=NutritionData(
+            energy=250.0,
+            fat=10.0,
+            carbohydrates=30.0,
+            protein=8.0,
+            sodium=150.0,
+            calcium=100.0,
+            iron=3.0,
+        ),
+        health_score=6,
+        recommendations="Reduce cholesterol intake.",
+    )
+
+
+def test_analyze_food():
+    client = TestClient(app)
+    image_path = Path(__file__).with_name("brackfast.jpg")
+
+    with patch("backend.call_chatgpt5", new=mock_call_chatgpt5):
+        with image_path.open("rb") as img:
+            files = {"file": ("brackfast.jpg", img, "image/jpeg")}
+            data = {"context": "I have a bit high cholesterol level"}
+            response = client.post("/analyze/test_user", files=files, data=data)
+
+    assert response.status_code == 200
+    result = response.json()
+    assert result["health_score"] == 6
+    assert result["recommendations"] == "Reduce cholesterol intake."


### PR DESCRIPTION
## Summary
- add pytest dependency to support API testing
- create endpoint test that posts a sample image with cholesterol context

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68a6216fd2948323adce2a75bc4d4cc5