### PR TITLE
Add API test harness and requests dependency

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -2,3 +2,5 @@ fastapi
 uvicorn
 openai
 python-multipart
+
+requests

--- a/test/harness.py
+++ b/test/harness.py
@@ -1,0 +1,19 @@
+import requests
+from pathlib import Path
+
+
+def main():
+    url = "http://127.0.0.1:8000/analyze/test-user"
+    image_path = Path(__file__).parent / "brackfast.jpg"
+    context = "I have a high cholesterol level"
+
+    with open(image_path, "rb") as img_file:
+        files = {"file": (image_path.name, img_file, "image/jpeg")}
+        data = {"context": context}
+        response = requests.post(url, files=files, data=data)
+
+    print(response.text)
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- add `test/harness.py` script to call local API with test image and context
- include `requests` in requirements for harness

## Testing
- `python -m pytest`

------
https://chatgpt.com/codex/tasks/task_e_68a6237e1100832389af84676c9ad3aa